### PR TITLE
Fix import name case error

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -1,5 +1,5 @@
 var repl = require("repl");
-var tinyLisp = require("./tinyLisp").tinyLisp;
+var tinyLisp = require("./tinylisp").tinyLisp;
 
 repl.start({
   prompt: "> ",


### PR DESCRIPTION
repl.js imports "./tinyLisp", but the actual file is called
"tinylisp" (note lowercase L). This breaks on Linux since
the file system is case-sensitive.
