### PR TITLE
Add if, and, or

### DIFF
--- a/tinylisp.js
+++ b/tinylisp.js
@@ -48,6 +48,22 @@
     return interpret(input[2], letCtx);
   }
 
+  var if_ = function(input, ctx) {
+    return interpret(input[1], ctx) ?
+      interpret(input[2], ctx) :
+      interpret(input[3], ctx);
+  }
+
+  var shortCircuit = function(input, ctx, tshort) {
+    input.shift();
+    var expr;
+    while ((expr = input.shift())) {
+      if (interpret(expr, ctx) == tshort)
+        return tshort;
+    }
+    return !tshort;
+  }
+
   var fn = function(input, ctx) {
     return {
       type: "function",
@@ -65,6 +81,9 @@
       case "lambda": return lambda(input, ctx);
       case "letrec": return let(input, ctx, true);
       case "let":    return let(input, ctx, false);
+      case "if":     return if_(input, ctx);
+      case "or":     return shortCircuit(input, ctx, true);
+      case "and":    return shortCircuit(input, ctx, false);
       default:
         var list = input.map(function(x) { return interpret(x, ctx); });
         if (list[0].type === "function") {

--- a/tinylisp.spec.js
+++ b/tinylisp.spec.js
@@ -157,5 +157,46 @@ describe('tinyLisp', function() {
         expect(t.interpret(t.parse("(letrec () 42)"))).toEqual(42);
       });
     });
+
+    describe('if', function() {
+      it('should choose the right branch', function() {
+        expect(t.interpret(t.parse("(if 1 42 4711)"))).toEqual(42);
+        expect(t.interpret(t.parse("(if 0 42 4711)"))).toEqual(4711);
+      });
+    });
+
+    describe('and', function() {
+      it('should be true when empty', function() {
+        expect(t.interpret(t.parse("(and)"))).toEqual(true);
+      });
+
+      it('should be false if any operand is false', function() {
+        expect(t.interpret(t.parse("(and 1 1 0 1)"))).toEqual(false);
+        expect(t.interpret(t.parse("(and 0 1"))).toEqual(false);
+        expect(t.interpret(t.parse("(and 1 0"))).toEqual(false);
+      });
+
+      it('should be true if all operands are true', function() {
+        expect(t.interpret(t.parse("(and 1 1"))).toEqual(true);
+        expect(t.interpret(t.parse("(and 1"))).toEqual(true);
+      });
+    });
+
+    describe('or', function() {
+      it('should be false when empty', function() {
+        expect(t.interpret(t.parse("(or)"))).toEqual(false);
+      });
+
+      it('should be true if any operand is true', function() {
+        expect(t.interpret(t.parse("(or 1 1 0 1)"))).toEqual(true);
+        expect(t.interpret(t.parse("(or 0 1"))).toEqual(true);
+        expect(t.interpret(t.parse("(or 1 0"))).toEqual(true);
+      });
+
+      it('should be false if all operands are false', function() {
+        expect(t.interpret(t.parse("(or 0 0"))).toEqual(false);
+        expect(t.interpret(t.parse("(or 0"))).toEqual(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
And, or behave correctly with respect to short-circuiting.
Since we have no side-effects, this turns out to be difficult to test automatically.
