### PR TITLE
Added defunc

### DIFF
--- a/littlelisp.js
+++ b/littlelisp.js
@@ -36,6 +36,20 @@
 
       return interpret(input[2], letContext);
     },
+    
+    defunc: function(input, context) {
+      context.scope[input[1][0].value] = function() {
+        console.log('args');
+        console.log(arguments);
+        var funcArguments = arguments;
+        var funcScope = input[1][1].reduce(function(acc, x, i) {
+          acc[x.value] = funcArguments[i];
+          return acc;
+        }, {});
+        return interpret(input[1][2], new Context(funcScope, context));
+      };
+      return interpret(input[2], context);
+    },
 
     lambda: function(input, context) {
       return function() {


### PR DESCRIPTION
This was tricky to figure out. Adding functions to lisp code makes the coding process much more friendly. When trying to make programs, I kept wanting to make functions rather than lambdas. In an attempt to fix this issue,  I added defunc, the lisp function, in the same style as the rest of the code.

If there is anything that should be changed in the code, feel free to make such changes.